### PR TITLE
Created new mehods.

### DIFF
--- a/examples/index.htm
+++ b/examples/index.htm
@@ -19,15 +19,24 @@
     </div>
     
     <script type="text/javascript" src="../libs/jquery.min.js"></script>
-    <script type="text/javascript" src="../dist/js/jquery.jInvertScroll.min.js"></script>
+    <script type="text/javascript" src="../src/jquery.jInvertScroll.js"></script>
     <script type="text/javascript">
     (function($) {
-        $.jInvertScroll(['.scroll'],        // an array containing the selector(s) for the elements you want to animate
+        var elem = $.jInvertScroll(['.scroll'],        // an array containing the selector(s) for the elements you want to animate
             {
             height: 6000,                   // optional: define the height the user can scroll, otherwise the overall length will be taken as scrollable height
             onScroll: function(percent) {   //optional: callback function that will be called when the user scrolls down, useful for animating other things on the page
                 console.log(percent);
             }
+        });
+
+        $(window).resize(function() {
+          if ($(window).width() <= 768) {
+            elem.destroy();
+          }
+          else {
+            elem.reinitialize();
+          }
         });
     }(jQuery));
     </script>

--- a/src/jquery.jInvertScroll.js
+++ b/src/jquery.jInvertScroll.js
@@ -50,63 +50,94 @@
             totalHeight,
             winHeight,
             winWidth;
-        
-        // Extract all selected elements from dom and save them into an array
-        $.each(sel, function(i, val) {
-            $(val).each(function(e) {
-                elements.push($(this));
-                
-                var w = $(this).width();
-                if(longest < w) {
-                    longest = w;
-                }
-            });
-        });
-        
-        // Use the longest elements width + height if set to auto
-        if(config.width == 'auto') {
-            config.width = longest;
-        }
-        
-        if(config.height == 'auto') {
-            config.height = longest;
-        }
-        
-        // Set the body to the selected height
-        $('body').css('height', config.height+'px');
-        
-        $([document, window]).on('ready resize', function (e) {
-            totalHeight = $(document).height();
-            winHeight = $(window).height();
-            winWidth = $(window).width();
-        });
 
-        // Listen for the actual scroll event
-        $(window).on('scroll resize', function (e) {
+        function init() {
+            // Extract all selected elements from dom and save them into an array
+            $.each(sel, function (i, val) {
+              $(val).each(function (e) {
+                elements.push($(this));
+
+                var w = $(this).width();
+                if (longest < w) {
+                  longest = w;
+                }
+              });
+            });
+
+            // Use the longest elements width + height if set to auto
+            if (config.width == 'auto') {
+              config.width = longest;
+            }
+
+            if (config.height == 'auto') {
+              config.height = longest;
+            }
+
+            // Set the body to the selected height
+            $('body').css('height', config.height + 'px');
+        }
+
+        function calc() {
+          totalHeight = $(document).height();
+          winHeight = $(window).height();
+          winWidth = $(window).width();
+        }
+
+        function onscroll(e) {
             var currY = $(this).scrollTop();
-            
+
+            // Make calculations
+            calc();
+
             var diff = totalHeight - winHeight;
             var scrollPercent = 0;
-            
+
             if (diff != 0) {
-                // Current percentual position
-                var scrollPercent = (currY / diff).toFixed(4);
+              // Current percentual position
+              scrollPercent = (currY / diff).toFixed(4);
             }
-            
+
             // Call the onScroll callback
             if(typeof config.onScroll === 'function') {
-                config.onScroll.call(this, scrollPercent);
+              config.onScroll.call(this, scrollPercent);
             }
-            
+
             // do the position calculation for each element
             $.each(elements, function (i, el) {
-                var deltaW = el.width() - winWidth;
-                if (deltaW <= 0) {
-                    deltaW = el.width();
-                }
-                var pos = Math.floor(deltaW * scrollPercent) * -1;
-                el.css('left', pos);
+              var deltaW = el.width() - winWidth;
+              if (deltaW <= 0) {
+                deltaW = el.width();
+              }
+              var pos = Math.floor(deltaW * scrollPercent) * -1;
+              el.css('left', pos);
             });
-        });
+        }
+
+        function setlisteners() {
+            // Listen for the actual scroll event
+            $(window).on('scroll resize', onscroll);
+            $([document, window]).on('ready resize', calc);
+        }
+
+
+        // Init actions
+        init();
+        setlisteners();
+
+
+        return {
+            reinitialize: function() {
+                init();
+                setlisteners();
+            },
+            destroy: function() {
+                // Remove previously added inline styles
+                $('body').attr('style', '');
+
+                // Remove listeners
+                $(window).off('scroll resize', onscroll);
+                $([document, window]).off('ready resize', calc);
+            }
+        };
     };
 }(jQuery));


### PR DESCRIPTION
I had some problems with the master branch of jInvertScroll to remove the horizontal scroll behavior for my responsive site. So, I've added two public methods: 
- `reinitialize`: As it name says, it reinitialize the behavior with the previous given settings.
- `destroy`: Destroy the horizontal scroll behavior by removing `document.body` inline styles and the listeners.

Maybe it could be done much better, but its a quick way to make it work as I expected. 
